### PR TITLE
Add support for quality data!

### DIFF
--- a/includes/LIMSrawseq.inc
+++ b/includes/LIMSrawseq.inc
@@ -71,8 +71,8 @@ class LIMSrawseq extends ChadoCustomSearch {
       'technology' => [
         'title' => 'Technology',
       ],
-      'read_type' => [
-        'title' => 'Read Type',
+      'library_type' => [
+        'title' => 'Library',
       ],
       'germplasm' => [
         'title' => 'Germplasm Name',
@@ -95,6 +95,10 @@ class LIMSrawseq extends ChadoCustomSearch {
       'read_type' => [
         'title' => 'Read Type',
         'help' => 'The method used to generate the reads.'
+      ],
+      'library_type' => [
+        'title' => 'Library Type',
+        'help' => 'The method of library preparation for sequencing.',
       ],
       'germplasm' => [
         'title' => 'Germplasm Name',
@@ -143,11 +147,17 @@ class LIMSrawseq extends ChadoCustomSearch {
     $form['technology']['#options'] = $tech;
     $form['technology']['#empty_option'] = '- Select Technology -';
 
-    // Make Technology Drop-down.
+    // Make Read Type Drop-down.
     $read_type =  db_query('SELECT read_type FROM {lims_seqrun} GROUP BY read_type')->fetchAllKeyed(0,0);
     $form['read_type']['#type'] = 'select';
     $form['read_type']['#options'] = $read_type;
     $form['read_type']['#empty_option'] = '- Select Read Type -';
+
+    // Make Library Type Drop-down.
+    $library_type = db_query('SELECT library_type FROM {lims_seqrun} GROUP BY library_type')->fetchAllKeyed(0,0);
+    $form['library_type']['#type'] = 'select';
+    $form['library_type']['#options'] = $library_type;
+    $form['library_type']['#empty_option'] = '- Select Library Type -';
 
     return $form;
   }
@@ -179,7 +189,7 @@ class LIMSrawseq extends ChadoCustomSearch {
     $query = "SELECT
         main.run_name,
         main.technology,
-        main.read_type,
+        main.library_type,
         string_agg(o.species, ', ') as species,
         single_stock.name as germplasm
       FROM [lims_seqrun] main
@@ -223,6 +233,11 @@ class LIMSrawseq extends ChadoCustomSearch {
       $where[] = "main.read_type ~* :read_type";
       $args[':read_type'] = $filter_results['read_type'];
     }
+    // -- Library Type.
+    if ($filter_results['library_type'] != '') {
+      $where[] = "main.library_type ~* :library_type";
+      $args[':library_type'] = $filter_results['library_type'];
+    }
     // -- Name.
     if ($filter_results['run_name'] != '') {
       $where[] = "main.run_name ~* :run_name";
@@ -238,7 +253,7 @@ class LIMSrawseq extends ChadoCustomSearch {
     }
 
     // Group it.
-    $query .= "\n" . ' GROUP BY main.run_id, main.run_name, main.technology, main.read_type, single_stock.name';
+    $query .= "\n" . ' GROUP BY main.run_id, main.run_name, main.technology, main.library_type, single_stock.name';
     // Sort even though it is SLOW b/c ppl expect it.
     $query .= "\n" . ' ORDER BY main.run_id DESC';
 

--- a/includes/TripalImporter/LimsSampleQualityImporter.inc
+++ b/includes/TripalImporter/LimsSampleQualityImporter.inc
@@ -113,6 +113,7 @@ class LimsSampleQualityImporter extends TripalImporter {
       $run_name = $cols[0];
       $sample_name = $cols[1];
       $sample_accession = $cols[2];
+      // First we try using the assumption that this run only has a single sample.
       $sql = "
         SELECT s.sample_id
         FROM lims_seqrun_samples s
@@ -125,7 +126,26 @@ class LimsSampleQualityImporter extends TripalImporter {
         ':run' => $run_name
       ])->fetchField();
       if (!$sample_id) {
-        continue;
+        // If that assumption wasn't valid, then we make the assumption
+        // this is a multi-sample run.
+        $sql = "
+          SELECT s.sample_id
+          FROM {lims_seqrun_samples} s
+          INNER JOIN {lims_seqrun} r ON r.samples_fid=s.samples_fid
+          WHERE r.run_name=:run
+            AND s.sample_name=:name AND s.sample_accession=:accession";
+        $sample_id = db_query($sql, [
+          ':name' => $sample_name,
+          ':accession' => $sample_accession,
+          ':run' => $run_name,
+        ])->fetchField();
+
+        // If that still didn't work then we're out of ideas *shrugs*.
+        if (!$sample_id) {
+          $msg = "Unable to find the sample $sample_name ($sample_accession).";
+          $this->logMessage($msg);
+          continue;
+        }
       }
 
       // 2) Next lets save the quality information!

--- a/includes/TripalImporter/LimsSampleQualityImporter.inc
+++ b/includes/TripalImporter/LimsSampleQualityImporter.inc
@@ -1,0 +1,160 @@
+<?php
+/**
+ * For importing quality data for a set of samples (e.g. number of reads).
+ */
+class LimsSampleQualityImporter extends TripalImporter {
+
+  /**
+   * The name of this loader.  This name will be presented to the site
+   * user.
+   */
+  public static $name = 'LIMS Sample Quality Importer';
+
+  /**
+   * The machine name for this loader. This name will be used to construct
+   * the URL for the loader.
+   */
+  public static $machine_name = 'lims_samplequality_loader';
+
+  /**
+   * A brief description for this loader.  This description will be
+   * presented to the site user.
+   */
+  public static $description = 'Attach quality information to LIMS records such as number of reads, basepairs and depth on a per sample basis.';
+
+  /**
+   * An array containing the extensions of allowed file types.
+   */
+  public static $file_types = ['txt', 'tsv'];
+
+  /**
+   * A boolean indicated whether to require an analysis for the import job.
+   */
+  public static $use_analysis = FALSE;
+
+  /**
+   * Provides information to the user about the file upload.  Typically this
+   * may include a description of the file types allowed.
+   */
+  public static $upload_description = '<p>Quality information is provided on a per sample basis in a simple tab-delimited file with the following columns:</p>
+    <ol>
+      <li><strong>LIMS Run Name</strong>:</li>
+      <li><strong>Sample Name</strong>: The name of the sample as it appears in LIMS.</li>
+      <li><strong>Sample Accession</strong>: The accession of the sample as determined by LIMS.</li>
+      <li><strong>Read Count</strong>: The number of reads yielded by sequencing.</li>
+      <li><strong>Base Count</strong>: The total number of bases yielded by sequencing.</li>
+      <li><strong>Estimated Depth</strong>: This is calculated using the total base count and dividing it by the expected number of bases in the target region. The target region will be dependent upon the library type (Whole genome, exome capture, etc).</li>
+      <li><strong>Maximum Read Length</strong>: The number fo bases in the largest read sequenced.</li>
+      <li><strong>N50 Value</strong>: Where contigs are considered from longest to shortest, the number of contigs in which half the assembly is contained in.</li>
+      <li><strong>N50 Size</strong>: Where contigs are ordered from longest to shortest, the sequence length of the shortest contig at 50% of the total genome length.</li>
+      <li><strong>Quality Note</strong>: Free text comments pertaining to the quality of the run.</li>
+    </ol>';
+
+  /**
+   * Indicates the methods that the file uploader will support.
+   */
+  public static $methods = [
+    // Allow the user to upload a file to the server.
+    'file_upload' => TRUE,
+    // Allow the user to provide the path on the Tripal server for the file.
+    'file_local' => TRUE,
+    // Allow the user to provide a remote URL for the file.
+    'file_remote' => TRUE,
+  ];
+
+  /**
+   * @see TripalImporter::run()
+   */
+  public function run() {
+
+    // All values provided by the user in the Importer's form widgets are
+    // made available to us here by the Class' arguments member variable.
+    $arguments = $this->arguments['run_args'];
+
+    // The path to the uploaded file is always made available using the
+    // 'files' argument. The importer can support multiple files, therefore
+    // this is an array of files, where each has a 'file_path' key specifying
+    // where the file is located on the server.
+    $file_path = $this->arguments['files'][0]['file_path'];
+
+    // We want to provide a progress report to the end-user so that they:
+    // 1) Recognize that the loader is not hung if running a large file, but is
+    //    executing
+    // 2) Provides some indicatation for how long the file will take to load.
+    //
+    // Here we'll get the size of the file and tell the TripalImporter how
+    // many "items" we have to process (in this case bytes of the file).
+    $filesize = filesize($file_path);
+    $this->setTotalItems($filesize);
+    $this->setItemsHandled(0);
+
+    // Loop through each line of file.  We use the fgets function so as not
+    // to load the entire file into memory but rather to iterate over each
+    // line separately.
+    $bytes_read = 0;
+    $in_fh = fopen($file_path, "r");
+    $header = explode("\t",fgets($in_fh));
+    while ($line = fgets($in_fh)) {
+
+      // Calculate how many bytes we have read from the file and let the
+      // importer know how many have been processed so it can provide a
+      // progress indicator.
+      $bytes_read += drupal_strlen($line);
+      $this->setItemsHandled($bytes_read);
+
+      // Remove any trailing white-space from the line.
+      $line = trim($line);
+
+      // Split line on a comma into an array.  The feature name appears in the
+      // first "column" of data and the property in the second.
+      $cols = explode("\t", $line);
+
+      // 1) Find the sample we are attaching quality data to.
+      $run_name = $cols[0];
+      $sample_name = $cols[1];
+      $sample_accession = $cols[2];
+      $sql = "
+        SELECT s.sample_id
+        FROM lims_seqrun_samples s
+        INNER JOIN lims_seqrun r ON r.sample_id=s.sample_id
+        WHERE r.run_name=:run
+          AND s.sample_name=:name AND s.sample_accession=:accession";
+      $sample_id = db_query($sql, [
+        ':name' => $sample_name,
+        ':accession' => $sample_accession,
+        ':run' => $run_name
+      ])->fetchField();
+      if (!$sample_id) {
+        continue;
+      }
+
+      // 2) Next lets save the quality information!
+      for($i = 3; $i <= sizeof($cols); $i++) {
+        if ($cols[$i]) {
+          $info_label = trim($header[$i]);
+          $value = trim($cols[$i]);
+          $sample_info_id = db_select('lims_seqrun_samples_info', 'info')
+            ->fields('info', ['sample_info_id'])
+            ->condition('sample_id', $sample_id)
+            ->condition('info_label', $info_label)
+            ->execute()->fetchField();
+
+          if ($sample_info_id) {
+            db_update('lims_seqrun_samples_info')
+              ->fields(['value' => $value])
+              ->condition('sample_info_id', $sample_info_id)
+              ->execute();
+          }
+          else {
+            db_insert('lims_seqrun_samples_info')
+              ->fields([
+                'sample_id' => $sample_id,
+                'info_label' => $info_label,
+                'value' => $value,
+              ])->execute();
+          }
+        }
+      }
+    }
+  }
+}

--- a/lims.install
+++ b/lims.install
@@ -36,6 +36,51 @@ function lims_update_7003(&$sandbox) {
 }
 
 /**
+ * Add support for quality information.
+ */
+function lims_update_7004(&$sandbox) {
+  $table = array(
+    'description' => 'Additional information for samples including quality stats.',
+    'fields' => array(
+      'sample_info_id' => array(
+        'description' => 'The primary identifier for a piece of sample information.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'sample_id' => array(
+        'description' => 'The primary identifier for a sample.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'info_label' => array(
+        'description' => 'A human-readable label for the type of information (e.g. "Number of Bases").',
+        'type' => 'varchar',
+        'length' => 150,
+      ),
+      'value' => array(
+        'description' => 'The piece of information.',
+        'type' => 'text',
+      ),
+    ),
+   'indexes' => array(
+      'sample_info_label' => array('info_label'),
+      'sample_id' => array('sample_id'),
+    ),
+    'unique keys' => array(),
+    'foreign keys' => array(
+      'lims_seqrun_samples' => array(
+        'table' => 'lims_seqrun_samples',
+        'columns' => array('sample_id' => 'sample_id'),
+      ),
+    ),
+    'primary key' => array('sample_info_id'),
+  );
+  db_create_table('lims_seqrun_samples_info', $table);
+}
+
+/**
  * Implements hook_schema().
  * Defines our database tables to the Drupal Schema API which then
  * creates/removes them on installation/uninstallation of our module.
@@ -242,5 +287,45 @@ function lims_schema() {
     'foreign keys' => array( ),
     'primary key' => array('sample_id'),
   );
+
+  $schema['lims_seqrun_samples_info'] = array(
+    'description' => 'Additional information for samples including quality stats.',
+    'fields' => array(
+      'sample_info_id' => array(
+        'description' => 'The primary identifier for a piece of sample information.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'sample_id' => array(
+        'description' => 'The primary identifier for a sample.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'info_label' => array(
+        'description' => 'A human-readable label for the type of information (e.g. "Number of Bases").',
+        'type' => 'varchar',
+        'length' => 150,
+      ),
+      'value' => array(
+        'description' => 'The piece of information.',
+        'type' => 'text',
+      ),
+    ),
+   'indexes' => array(
+      'sample_info_label' => array('info_label'),
+      'sample_id' => array('sample_id'),
+    ),
+    'unique keys' => array(),
+    'foreign keys' => array(
+      'lims_seqrun_samples' => array(
+        'table' => 'lims_seqrun_samples',
+        'columns' => array('sample_id' => 'sample_id'),
+      ),
+    ),
+    'primary key' => array('sample_info_id'),
+  );
+
   return $schema;
 }

--- a/lims.module
+++ b/lims.module
@@ -250,6 +250,20 @@ function seqrun_load(&$nodes) {
     }
   }
 
+  // Add quality Information to any samples which were collected.
+  foreach ($nodes as $nid => $node) {
+    foreach ($node->samples as $k => $sample) {
+      $sample_id = $sample->sample_id;
+      $results = db_select('lims_seqrun_samples_info', 'info')
+        ->fields('info', ['sample_info_id', 'info_label', 'value'])
+        ->condition('info.sample_id', $sample_id)
+        ->orderBy('info.sample_info_id', 'ASC')
+        ->execute();
+      foreach($results as $r) {
+        $node->samples[$k]->quality_info[$r->info_label] = $r->value;
+      }
+    }
+  }
 }
 
 /**

--- a/theme/lims-seqrun-node.tpl.php
+++ b/theme/lims-seqrun-node.tpl.php
@@ -2,7 +2,95 @@
 /**
  * This template is used to render the Sequencing Run on the page.
  */
+drupal_add_library('system', 'drupal.collapse');
 $node = $node['#node'];
+
+// Prepare Species for display.
+$species = array();
+foreach ($node->species as $s) {
+  $species[] = '<i>' . $s->genus . ' ' . $s->species . '</i>';
+}
+
+// Compile data for the overview.
+$overview_data = [];
+$overview_data[] = ['Name', $node->seqrun->run_name];
+$overview_data[] = ['Species', implode(', ', $species)];
+$overview_data[] = ['Library Type', $node->seqrun->library_type];
+$overview_data[] = ['Insert Length (bp)', $node->seqrun->insert_length];
+$overview_data[] = ['Fragment Length (bp)', $node->seqrun->fragment_length];
+$overview_data[] = ['Index Type', $node->seqrun->index_type];
+$overview_data[] = ['Technology', $node->seqrun->technology];
+$overview_data[] = ['Read Type', $node->seqrun->read_type];
+
+$file_data = [];
+$file_data[] = ['File', $node->seqrun->filename];
+$file_data[] = ['MD5 Checksum', $node->seqrun->md5sum];
+
+// Compile data for samples.
+// -- If we have a single sample then we want to show a simple list...
+$single_sample = (sizeof($node->samples) == 1) ? TRUE: FALSE;
+if ($single_sample) {
+
+  $sample = $node->samples[0];
+
+  $entity_id = FALSE;
+  if (isset($sample->sample_stock_id) AND $sample->sample_stock_id > 0) {
+    $entity_id = chado_get_record_entity_by_table('stock', $sample->sample_stock_id);
+  }
+  $sample_accession = ($entity_id) ? l($sample->sample_accession, 'bio_data/'.$entity_id, array('attributes' => array('target' => '_blank'))) : $sample->sample_accession;
+
+
+  $sample_data = [];
+  $sample_data[] = ['Name', $sample->sample_name];
+  $sample_data[] = ['Accession', $sample_accession];
+  $sample_data[] = ['Description', $sample->sample_description];
+
+  $sample_quality_data = [];
+  foreach ($sample->quality_info as $label => $value) {
+    $sample_quality_data[] = [$label, $value];
+  }
+}
+// -- If we have a multi-sample run then we want to show a table...
+elseif (!$single_sample AND !empty($node->samples)) {
+
+  $sample_data = [];
+  $have_quality = FALSE;
+  foreach ($node->samples as $sample) {
+
+    $entity_id = FALSE;
+    if (isset($sample->sample_stock_id) AND $sample->sample_stock_id > 0) {
+      $entity_id = chado_get_record_entity_by_table('stock', $sample->sample_stock_id);
+    }
+    $sample_accession = ($entity_id) ? l($sample->sample_accession, 'bio_data/'.$entity_id, array('attributes' => array('target' => '_blank'))) : $sample->sample_accession;
+
+    $sample_data[] = array(
+      $sample->index_id,
+      $sample->index_seq,
+      $sample->sample_name,
+      $sample_accession,
+      $sample->plate_well,
+      $sample->sample_description
+    );
+
+
+    if ($sample->quality_info) {
+      $have_quality = TRUE;
+      $sample_quality_data[] = array_merge(
+        ['Name' => $sample->sample_name, 'Accession' => $sample_accession],
+        $sample->quality_info
+      );
+      foreach ($sample->quality_info as $label => $value) {
+        $sample_quality_header[$label] = $label;
+      }
+    }
+    else {
+      $sample_quality_data[] = [
+        'Name' => $sample->sample_name,
+        'Accession' => $sample_accession
+      ];
+    }
+  }
+}
 ?>
 
 <style>
@@ -14,73 +102,155 @@ a.indices-link {
 h2.samples-table-title {
   margin-top: 0;
 }
+.vertical-header th {
+  width: 20%;
+}
 
 </style>
 
+<!-- OVERVIEW -->
+<fieldset id="lims-overview" class="collapsible form-wrapper">
+  <legend><span class="fieldset-legend">
+    <a class="fieldset-title" href="#"><span class="fieldset-legend-prefix element-invisible">Hide</span> Overview</a><span class="summary"></span></span>
+  </legend>
+  <div class="fieldset-wrapper">
+
+    <table id="overview" class="vertical-header">
+      <caption>Basic Information</caption>
+      <tbody>
+        <?php foreach ($overview_data as $row) :
+            if (!empty($row[1])) : ?>
+              <tr><th><?php print $row[0]?></th><td><?php print $row[1]?></td></tr>
+        <?php endif; endforeach; ?>
+      </tbody>
+    </table>
+
+    <table id="file" class="vertical-header">
+      <caption>File Information</caption>
+      <tbody>
+        <?php foreach ($file_data as $row) :
+          if (!empty($row[1])) : ?>
+          <tr><th><?php print $row[0]?></th><td><?php print $row[1]?></td></tr>
+        <?php else : ?>
+          <tr><th><?php print $row[0]?></th><td><span class="empty">Not available</span></td></tr>
+        <?php endif; endforeach; ?>
+      </tbody>
+    </table>
+
+    <p><?php print $node->seqrun->description; ?></p>
+
+  </div>
+</fieldset>
+
+<!-- SAMPLES -->
+<fieldset id="lims-samples-list" class="collapsible collapsed form-wrapper">
+  <legend><span class="fieldset-legend">
+    <a class="fieldset-title" href="#"><span class="fieldset-legend-prefix element-invisible">Hide</span> Sample(s) List</a><span class="summary"></span></span>
+  </legend>
+  <div class="fieldset-wrapper">
+
+    <?php if ($single_sample) : ?>
+
+      <table id="sample" class="vertical-header single-sample">
+        <tbody>
+          <?php foreach ($sample_data as $row) :
+              if (!empty($row[1])) : ?>
+                <tr><th><?php print $row[0]?></th><td><?php print $row[1]?></td></tr>
+          <?php endif; endforeach; ?>
+        </tbody>
+      </table>
+
+    <?php elseif (empty($samples)): ?>
+
+      <br />
+      <h3 style="margin:0;padding:0;color:red">No samples uploaded for this Sequencing Run.</h3>
+      <div>Please Edit this page and upload a tab-delimited file adhering to the specifications mentioned under "Samples Details"</div>
+
+    <?php else: ?>
+
+      <table id="sample" class="horizontal-header multi-sample">
+        <thead>
+          <tr><th colspan="2">Index</th><th colspan="4">Sample</th></tr>
+          <tr>
+            <th>ID</th><th>Sequence</th>
+            <th>Name</th><th>Accession</th><th>Plate Well</th><th>Description</th></th>
+        </thead>
+        <tbody>
+          <?php foreach ($sample_data as $row) :?>
+            <tr>
+              <?php foreach ($row as $cell) : ?>
+                <td><?php print $cell;?></td>
+              <?php endforeach; ?>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+
+    <?php endif; ?>
+
+  </div>
+</fieldset>
+
+<!-- QUALITY -->
+<fieldset id="lims-sample-quality" class="collapsible collapsed form-wrapper">
+  <legend><span class="fieldset-legend">
+    <a class="fieldset-title" href="#"><span class="fieldset-legend-prefix element-invisible">Hide</span> Quality Statistics</a><span class="summary"></span></span>
+  </legend>
+  <div class="fieldset-wrapper">
+
+    <?php if ($single_sample AND $have_quality) : ?>
+
+      <table id="quality" class="vertical-header single-sample">
+        <tbody>
+          <?php foreach ($sample_quality_data as $row) :
+              if (!empty($row[1])) : ?>
+                <tr><th><?php print $row[0]?></th><td><?php print $row[1]?></td></tr>
+          <?php endif; endforeach; ?>
+        </tbody>
+      </table>
+
+    <?php elseif (!$have_quality): ?>
+
+      <br />
+      <h3 style="margin:0;padding:0;color:red">No quality data available for this Sequencing Run.</h3>
+      <div>Please upload it using the LIMS Sample Quality Tripal Importer</div>
+
+    <?php else: ?>
+
+      <table id="quality" class="horizontal-header multi-sample">
+        <thead>
+          <tr><th colspan="2">Sample</th><th colspan="<?php print sizeof($sample_quality_header)+1;?>">Quality Statistics</th></tr>
+          <tr>
+            <th>Name</th><th>Accession</th>
+            <?php foreach($sample_quality_header as $header_cell): ?>
+              <th><?php print $header_cell;?></th>
+            <?php endforeach; ?>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($sample_quality_data as $row) :?>
+            <tr>
+              <td><?php print $row['Name'];?></td>
+              <td><?php print $row['Accession'];?></td>
+              <?php foreach ($sample_quality_header as $label) :
+                if (!isset($row[$label])) : ?>
+                <td></td>
+              <?php else: ?>
+                <td><?php print $row[$label];?></td>
+              <?php endif; endforeach; ?>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+
+    <?php endif; ?>
+
+  </div>
+</fieldset>
+
 <?php
-// Prepare Species for display.
-$species = array();
-foreach ($node->species as $s) {
-  $species[] = '<i>' . $s->genus . ' ' . $s->species . '</i>';
-}
 
-// Main Table
-//-------------------------
-$rows = array();
-$rows[] = array(
-  array( 'data' => 'Name', 'header' => TRUE, 'width' => '20%' ),
-  $node->seqrun->run_name
-);
-$rows[] = array(
-  array( 'data' => 'Species', 'header' => TRUE, 'width' => '20%' ),
-  implode(', ',$species)
-);
-$rows[] = array(
-  array( 'data' => 'Library Type', 'header' => TRUE, 'width' => '20%' ),
-  $node->seqrun->library_type
-);
-if (!empty($node->seqrun->insert_length)) {
-  $rows[] = array(
-    array( 'data' => 'Insert Length', 'header' => TRUE, 'width' => '20%' ),
-    $node->seqrun->insert_length . ' bp'
-  );
-}
-if (!empty($node->seqrun->fragment_length)) {
-  $rows[] = array(
-    array( 'data' => 'Fragment Length', 'header' => TRUE, 'width' => '20%' ),
-    $node->seqrun->fragment_length . ' bp'
-  );
-}
-$rows[] = array(
-  array( 'data' => 'Index Type', 'header' => TRUE, 'width' => '20%' ),
-  $node->seqrun->index_type
-);
-$rows[] = array(
-  array( 'data' => 'Technology', 'header' => TRUE, 'width' => '20%' ),
-  $node->seqrun->technology
-);
-$rows[] = array(
-  array( 'data' => 'Read Type', 'header' => TRUE, 'width' => '20%' ),
-  $node->seqrun->read_type
-);
-
-print theme('table',array('header' => array(), 'rows' => $rows));
-
-// Short File table
-//-------------------------
-$rows = array();
-$rows[] = array(
-  array( 'data' => 'File', 'header' => TRUE, 'width' => '20%' ),
-  $node->seqrun->filename
-);
-$rows[] = array(
-  array( 'data' => 'MD5 Checksum', 'header' => TRUE, 'width' => '20%' ),
-  $node->seqrun->md5sum
-);
-
-print theme('table',array('header' => array(), 'rows' => $rows));
-
-print '<br /><p>'.$node->seqrun->description.'</p>';
+/******
 
 // Samples Table
 //-------------------------
@@ -160,3 +330,4 @@ if (!empty($node->samples)) {
 else {
   print '<br /><h3 style="margin:0;padding:0;color:red">No samples uploaded for this Sequencing Run.</h3><div>Please Edit this page and upload a tab-delimited file adhering to the specifications mentioned under "Samples Details"</div>';
 }
+*/

--- a/theme/lims-seqrun-node.tpl.php
+++ b/theme/lims-seqrun-node.tpl.php
@@ -49,9 +49,11 @@ if ($single_sample) {
   $sample_data[] = ['Description', $sample->sample_description];
 
   $sample_quality_data = [];
-  foreach ($sample->quality_info as $label => $value) {
-    $have_quality = TRUE;
-    $sample_quality_data[] = [$label, $value];
+  if (isset($sample->quality_info)) {
+    foreach ($sample->quality_info as $label => $value) {
+      $have_quality = TRUE;
+      $sample_quality_data[] = [$label, $value];
+    }
   }
 }
 // -- If we have a multi-sample run then we want to show a table...
@@ -78,7 +80,7 @@ elseif (!$single_sample AND !empty($node->samples)) {
     );
 
 
-    if ($sample->quality_info) {
+    if (isset($sample->quality_info) and !empty($sample->quality_info)) {
       $have_quality = TRUE;
       $sample_quality_data[] = array_merge(
         ['Name' => $sample->sample_name, 'Accession' => $sample_accession],

--- a/theme/lims-seqrun-node.tpl.php
+++ b/theme/lims-seqrun-node.tpl.php
@@ -52,6 +52,9 @@ if ($single_sample) {
   if (isset($sample->quality_info)) {
     foreach ($sample->quality_info as $label => $value) {
       $have_quality = TRUE;
+      if (is_numeric($value)) {
+        $value = number_format($value);
+      }
       $sample_quality_data[] = [$label, $value];
     }
   }
@@ -82,13 +85,18 @@ elseif (!$single_sample AND !empty($node->samples)) {
 
     if (isset($sample->quality_info) and !empty($sample->quality_info)) {
       $have_quality = TRUE;
-      $sample_quality_data[] = array_merge(
+      $sample_quality_datum = array_merge(
         ['Name' => $sample->sample_name, 'Accession' => $sample_accession],
         $sample->quality_info
       );
       foreach ($sample->quality_info as $label => $value) {
         $sample_quality_header[$label] = $label;
+
+        if (is_numeric($value)) {
+          $sample_quality_datum[$label] = number_format($value);
+        }
       }
+      $sample_quality_data[] = $sample_quality_datum;
     }
     else {
       $sample_quality_data[] = [
@@ -238,8 +246,8 @@ h2.samples-table-title {
     <?php elseif (!$have_quality): ?>
 
       <br />
-      <h3 style="margin:0;padding:0;color:red">No quality data available for this Sequencing Run.</h3>
-      <div>Please upload it using the LIMS Sample Quality Tripal Importer</div>
+      <h3 style="margin:0;padding:0;">No quality data available for this Sequencing Run.</h3>
+      <div style="font-style:italic;">Please upload it using the LIMS Sample Quality Tripal Importer</div>
 
     <?php elseif ($have_quality): ?>
 

--- a/theme/lims-seqrun-node.tpl.php
+++ b/theme/lims-seqrun-node.tpl.php
@@ -30,6 +30,7 @@ $file_data[] = ['MD5 Checksum', $node->seqrun->md5sum];
 // -- If we have a single sample then we want to show a simple list...
 $single_sample = (sizeof($node->samples) == 1) ? TRUE: FALSE;
 $have_samples = FALSE;
+$have_quality = FALSE;
 if ($single_sample) {
 
   $sample = $node->samples[0];
@@ -49,6 +50,7 @@ if ($single_sample) {
 
   $sample_quality_data = [];
   foreach ($sample->quality_info as $label => $value) {
+    $have_quality = TRUE;
     $sample_quality_data[] = [$label, $value];
   }
 }

--- a/theme/lims-seqrun-node.tpl.php
+++ b/theme/lims-seqrun-node.tpl.php
@@ -109,6 +109,17 @@ if (!empty($node->samples)) {
 
     print '<br /><h2>Sample</h2>' . theme('table',array('header' => array(), 'rows' => $rows));
 
+    // Now Quality table.
+    if (isset($sample->quality_info)) {
+      $rows = [];
+      foreach($sample->quality_info as $label => $value) {
+        $rows[] = array(
+          array( 'data' => $label, 'header' => TRUE, 'width' => '20%' ),
+          $value
+        );
+      }
+      print '<br /><h2>Quality</h2>' . theme('table',array('header' => array(), 'rows' => $rows));
+    }
   }
   // CASE 2: Multiple samples.
   elseif (sizeof($node->samples) > 0) {


### PR DESCRIPTION
This PR adds support for importing and displaying quality information for LIMS sequencing runs.

## Testing
### Data import
Quality data is associated with an existing sequencing run using the "LIMS Sample Quality Importer"
1. Update the module including running `update.php` (Already done on staging)
2. Ensure you have given yourself permission to see the importer (People > Permissions then check "Importer: Use the LIMS Sample Quality Importer"  (Already done on staging)
3. Go to Admin > Tripal > Data Loaders > LIMS Sample Quality Importer and create a file based on the details provided for the importer. Here's the one already imported into staging: [lims-test.txt](https://github.com/UofS-Pulse-Binfo/lims_rawseq/files/3912405/lims-test.txt)
4. You can check that data inserted properly using the "Devel" tab on an existing sequencing run (go to `$node->samples[0]->quality_info` for example) or by looking at the database (see table `lims_seqrun_samples_info`).

### Data Display
1. Import test data using instructions above.
2. Go to runs matching the following criteria (example in staging):
    - single sample, no quality information (node/1782785)
    - single sample, has quality information (node/1782795)
    - multi-sample, no quality information (node/1782743)
    - multi-sample, has quality information (node/1782744)