### PR TITLE
Expand LIMS search to show quality information

### DIFF
--- a/includes/LIMSrawseq.inc
+++ b/includes/LIMSrawseq.inc
@@ -68,11 +68,11 @@ class LIMSrawseq extends ChadoCustomSearch {
       'run_name' => [
         'title' => 'Name',
       ],
-      'technology' => [
-        'title' => 'Technology',
-      ],
       'library_type' => [
         'title' => 'Library',
+      ],
+      'technology' => [
+        'title' => 'Technology',
       ],
       'germplasm' => [
         'title' => 'Germplasm Name',
@@ -84,6 +84,10 @@ class LIMSrawseq extends ChadoCustomSearch {
     // The filter criteria available to the user.
     // This is used to generate a search form which can be altered.
     'filters' => [
+      'genus' => [
+        'title' => 'Genus',
+        'help' => 'The scientific name of the germplasm the sequencing was performed on.',
+      ],
       'species' => [
         'title' => 'Species',
         'help' => 'The species of the germplasm the sequencing was performed on.',
@@ -128,6 +132,11 @@ class LIMSrawseq extends ChadoCustomSearch {
     $form = parent::form($form, $form_state);
 
     // Make Genus and Species Drop-downs.
+    $description = LIMSrawseq::$info['filters']['genus']['help'];
+    $form['genus']['#prefix'] = '<div id="scientific-nameform-item" class="scientific-name-element form-item"><label>Scientific Name</label>';
+    $form['species']['#suffix'] = '<div class="description">' . $description . '</div></div>';
+    unset($form['genus']['#description'], $form['species']['#description']);
+
     $genus = [];
     $species = [];
     $resource = chado_query('SELECT genus, species FROM {organism} WHERE organism_id IN (SELECT organism_id FROM [lims_seqrun_species])');
@@ -135,8 +144,10 @@ class LIMSrawseq extends ChadoCustomSearch {
       $genus[$r->genus] = $r->genus;
       $species[$r->species] = $r->species;
     }
-    //$form['genus']['#type'] = 'select';
-    //$form['genus']['#options'] = $genus;
+
+    $form['genus']['#type'] = 'select';
+    $form['genus']['#options'] = $genus;
+    $form['genus']['#empty_option'] = '- Select Genus -';
     $form['species']['#type'] = 'select';
     $form['species']['#options'] = $species;
     $form['species']['#empty_option'] = '- Select Species -';
@@ -190,7 +201,7 @@ class LIMSrawseq extends ChadoCustomSearch {
         main.run_name,
         main.technology,
         main.library_type,
-        string_agg(o.species, ', ') as species,
+        string_agg(o.genus||' '||o.species, ', ') as species,
         single_stock.name as germplasm
       FROM [lims_seqrun] main
       LEFT JOIN [lims_seqrun_species] sr_sp ON sr_sp.run_id=main.run_id

--- a/includes/LIMSrawseq.inc
+++ b/includes/LIMSrawseq.inc
@@ -288,19 +288,138 @@ class LIMSrawseq extends ChadoCustomSearch {
   public function formatResults(&$form, $results) {
     parent::formatResults($form, $results);
 
-    foreach ($form['results']['#rows'] as $k => &$row) {
+    $new_table = $form['results'];
+    $new_table['#rows'] = [];
+
+    foreach ($form['results']['#rows'] as $k => $row) {
+
 
       // Make the run name a link.
-      $nid = db_query('SELECT nid FROM {lims_seqrun} WHERE run_name=:name',
-        [':name' => $row['run_name']])->fetchField();
-      if ($nid) {
-        $row['run_name'] = l($row['run_name'], 'node/'.$nid);
+      $r = db_query('SELECT run_id, sample_id, samples_fid, nid FROM {lims_seqrun} WHERE run_name=:name',
+        [':name' => $row['run_name']])->fetchObject();
+      if ($r) {
+        $nid = $r->nid;
+        $run_id = $r->run_id;
+        $sample_id = $r->sample_id;
+        $samples_fid = $r->samples_fid;
+        if ($nid) {
+          $row['run_name'] = l($row['run_name'], 'node/'.$nid);
+        }
+      }
+      else {
+        tripal_report_error('lims', TRIPAL_WARNING, "Unable to find lims record for ".print_r($row));
       }
 
       // Provide default for germplasm column.
+      $multiple_germplasm = FALSE;
       if (empty($row['germplasm'])) {
+        $multiple_germplasm = TRUE;
         $row['germplasm'] = '<span class="multi-germ">mutliple samples</span>';
       }
+
+      // Get the quality table.
+      $sample_ids = [];
+      // -- If we have a single sample then just get the quality info for it.
+      if (($multiple_germplasm == FALSE) && ($sample_id)) {
+        $sample_ids = [$sample_id];
+      }
+      // -- If we have multiple samples then grab them all?
+      elseif (($multiple_germplasm == TRUE) && $samples_fid) {
+        $sample_ids = db_query("
+          SELECT sample_id FROM {lims_seqrun_samples} WHERE samples_fid=:fid",
+          [':fid' => $samples_fid])->fetchCol();
+      }
+      // -- Now get the quality table.
+      $new_row_markup = '';
+      $quality_table = $this->getQualityTable($sample_ids);
+      $num_samples = count($sample_ids);
+      if ($num_samples == 1) {
+        $new_row_markup .= '<p class="sample-count">Number of Samples: 1. Samples with quality are shown below.</p>';
+      }
+      else {
+        $new_row_markup .= '<p class="sample-count">Number of Samples: '.$num_samples.'. Samples with quality are shown below.</p>';
+      }
+      if (!empty($quality_table['rows'])) {
+        $new_row_markup .= theme('table', $quality_table);
+      }
+      else {
+        $new_row_markup .= '<p class="no-quality">There is no quality information available for this sequencing run.</p>';
+      }
+
+      // Our own table striping.
+      if ($strip == 'odd') {
+        $strip = 'even';
+      }
+      else {
+        $strip = 'odd';
+      }
+
+      $new_table['#rows'][] = [
+        'data' => $row,
+        'class' => ['visible-row', $strip],
+        'no_striping' => TRUE,
+      ];
+      $new_table['#rows'][] = [
+        'data' => [[
+          'data' => '<div class="quality-subtable">' . $new_row_markup . '</div>',
+          'colspan' => 5,
+        ]],
+        'class' => ['hidden-row', $strip],
+        'no_striping' => TRUE,
+      ];
     }
+
+    $form['results'] = $new_table;
+  }
+
+  /**
+   *
+   */
+  private function getQualityTable($sample_ids) {
+
+    // -- For each sample, select the quality info (if there is some).
+    foreach ($sample_ids as $sample_id) {
+      $quality = db_query('
+        SELECT s.sample_name, s.sample_accession, q.info_label, q.value
+        FROM {lims_seqrun_samples} s
+        INNER JOIN {lims_seqrun_samples_info} q ON s.sample_id=q.sample_id
+        WHERE s.sample_id=:sample_id', [':sample_id' => $sample_id])->fetchAll();
+      foreach ($quality as $q) {
+        $all_quality[$sample_id]['sample_name'] = $q->sample_name;
+        $all_quality[$sample_id]['sample_accession'] = $q->sample_accession;
+        if ($q->info_label) {
+          $all_quality[$sample_id][$q->info_label] = $q->value;
+        }
+      }
+    }
+    $quality_table = [
+      'header' => ['Sample Name', 'Sample Accession', 'Estimated Depth', 'Max Read Length', 'N50 Value', 'N50 Size'],
+      'rows' => [],
+    ];
+    foreach($all_quality as $details) {
+      $row = [
+        'name' => $details['sample_name'],
+        'accession' => $details['sample_accession'],
+      ];
+      $row['depth'] = '';
+      if (isset($details['Estimated Depth'])) {
+        $row['depth'] = number_format($details['Estimated Depth'], 2);
+      }
+      $row['maxread'] = '';
+      if (isset($details['Maximum Read Length'])) {
+        $row['maxread'] = number_format($details['Maximum Read Length']);
+      }
+      $row['n50value'] = '';
+      if (isset($details['N50 Value'])) {
+        $row['n50value'] = number_format($details['N50 Value']);
+      }
+      $row['n50size'] = '';
+      if (isset($details['N50 Size'])) {
+        $row['n50size'] = number_format($details['N50 Size']);
+      }
+
+      $quality_table['rows'][] = $row;
+    }
+    return $quality_table;
   }
 }

--- a/theme/lims-seqrun.search.css
+++ b/theme/lims-seqrun.search.css
@@ -20,3 +20,34 @@
 #chado-custom-search-form .scientific-name-element select#edit-species {
   width: 275px;
 }
+
+/*  - Quality Subtable */
+#chado-custom-search-form .visible-row {
+  font-weight: bold;
+}
+#chado-custom-search-form .hidden-row .quality-subtable {
+  margin: 5px 20px 5px 50px;
+}
+#chado-custom-search-form .hidden-row .quality-subtable th {
+  background-color: #ededed;
+  color: black;
+}
+#chado-custom-search-form .hidden-row {
+  border-bottom: 2px solid #ededed;
+}
+#chado-custom-search-form .hidden-row .sample-count {
+  font-style: italic;
+  font-size 0.8em;
+  margin-bottom: 0px;
+  margin-left: 5px;
+}
+#chado-custom-search-form .hidden-row table {
+  margin-top: 2px;
+}
+#chado-custom-search-form .hidden-row table th {
+  font-weight:normal;
+}
+#chado-custom-search-form .hidden-row .no-quality {
+  font-weight: bolder;
+  margin-left: 5px;
+}

--- a/theme/lims-seqrun.search.css
+++ b/theme/lims-seqrun.search.css
@@ -1,4 +1,22 @@
-.multi-germ {
+#chado-custom-search-form .multi-germ {
   color: gray;
   font-style: italic;
+}
+
+/*  - Scientific Name */
+#chado-custom-search-form .scientific-name-element .form-item label {
+  display: none;
+}
+#chado-custom-search-form .scientific-name-element .form-item .description {
+  display: none;
+}
+#chado-custom-search-form .scientific-name-element .form-item {
+  display: inline-block;
+  margin-bottom: 2px;
+}
+#chado-custom-search-form .scientific-name-element select {
+  width: 175px;
+}
+#chado-custom-search-form .scientific-name-element select#edit-species {
+  width: 275px;
 }

--- a/theme/lims-seqrun.search.css
+++ b/theme/lims-seqrun.search.css
@@ -22,9 +22,6 @@
 }
 
 /*  - Quality Subtable */
-#chado-custom-search-form .visible-row {
-  font-weight: bold;
-}
 #chado-custom-search-form .hidden-row .quality-subtable {
   margin: 5px 20px 5px 50px;
 }
@@ -33,16 +30,18 @@
   color: black;
 }
 #chado-custom-search-form .hidden-row {
-  border-bottom: 2px solid #ededed;
+  border-bottom: 2px solid #d3d3d3;
 }
 #chado-custom-search-form .hidden-row .sample-count {
   font-style: italic;
   font-size 0.8em;
   margin-bottom: 0px;
   margin-left: 5px;
+  color: #757575;
 }
 #chado-custom-search-form .hidden-row table {
   margin-top: 2px;
+  border: 2px solid #ededed;
 }
 #chado-custom-search-form .hidden-row table th {
   font-weight:normal;


### PR DESCRIPTION
This PR Expands the LIMS search to show quality information. The use case for this is researchers looking for data specific to a given germplasm who need a certain amount of sequencing coverage. This PR allows them to see that coverage information within the sequencing run search.

## Limitations:
- This functionality does not handle runs with multiple samples well. It will work as expected however the quality table can get unwieldy with 96 samples and currently is not truncated/paged. This is ok for KnowPulse since we currently only have quality information for single-sample nanopore runs but will need to be improved in the future.

## Testing:
(Live on Fresh)
1. While on this branch, check that the search (`search/sequences/raw`) works as expected with no quality information:
<img width="1444" alt="Screen Shot 2020-03-19 at 1 19 53 PM" src="https://user-images.githubusercontent.com/1566301/77106208-581d5a00-69e4-11ea-80df-6fb2bbf6b6a2.png">

2. Upload Quality information by going to `admin/tripal/loaders/lims_samplequality_loader`. Contact me for our quality data for KnowPulse which can be used as an example file. (done already on fresh)
3. Go back to the search and make sure it shows up appropriately. ( e.g CDC Robin)
<img width="1224" alt="Screen Shot 2020-03-19 at 1 23 37 PM" src="https://user-images.githubusercontent.com/1566301/77106535-e0036400-69e4-11ea-9268-a9400c525458.png">
