### PR TITLE
Added PacBio Hifi option to Sequence Technology

### DIFF
--- a/lims.module
+++ b/lims.module
@@ -293,6 +293,7 @@ function seqrun_form($node, $form_state) {
       'Illumina HiSeq X Ten',
       'Roche 454',
       'PacBio RS',
+      'PacBio HiFi',
       'Oxford Nanopore',
     ),
     'read_type' => array(


### PR DESCRIPTION
A very minor change requested by Akiko.
I tested on a kpclone by creating a sequencing run for a single (non-multiplexed) sample and selecting PacBio Hifi from the Sequencing Technology dropdown.