### PR TITLE
Added additional options to form dropdowns "Sequencing Technology" and "Library Type"

### DIFF
--- a/lims.install
+++ b/lims.install
@@ -81,6 +81,22 @@ function lims_update_7004(&$sandbox) {
 }
 
 /**
+ * Increases the character limit for the Library Type dropdown.
+ */
+function lims_update_7005(&$sandbox) {
+
+  $table = 'lims_seqrun';
+  $column = 'library_type';
+  $spec = array(
+    'description' => 'The method of library preparation for sequencing.',
+    'type' => 'varchar',
+    'length' => 100,
+  );
+  // Have to specify 2 columns, in this case the column name is staying the same
+  db_change_field($table,$column,$column,$spec);
+}
+
+/**
  * Implements hook_schema().
  * Defines our database tables to the Drupal Schema API which then
  * creates/removes them on installation/uninstallation of our module.
@@ -125,7 +141,7 @@ function lims_schema() {
       'library_type' => array(
         'description' => 'The method of library preparation for sequencing.',
         'type' => 'varchar',
-        'length' => 30
+        'length' => 100,
       ),
       'insert_length' => array(
         'description' => 'The length of the insert in base pairs.',

--- a/lims.module
+++ b/lims.module
@@ -291,9 +291,11 @@ function seqrun_form($node, $form_state) {
       'Illumina HiSeq 2500',
       'Illumina MiSeq',
       'Illumina HiSeq X Ten',
+      'Illumina NovaSeq6000',
       'Roche 454',
       'PacBio RS',
       'PacBio HiFi',
+      'Pacbio Revio',
       'Oxford Nanopore',
     ),
     'read_type' => array(
@@ -315,6 +317,7 @@ function seqrun_form($node, $form_state) {
       'Oxford Nanopore: ligation',
       'Oxford Nanopore: rapid',
       'Oxford Nanopore: PCR-cDNA',
+      'CRISPRclean Ribosomal RNA Depletion (Jumpcode Genomics)',
     ),
     'index_type' => array(
       'None',


### PR DESCRIPTION
**Issue #22**

## Motivation

As requested by Rob, 3 additional options were needed in the form dropdowns in order to enter new sequencing runs. Specifically:
**Sequencing Technology**: Illumina NovaSeq6000, Pacbio Revio
**Library Type**: CRISPRclean Ribosomal RNA Depletion (Jumpcode Genomics)

## What does this PR do?

Adds the above options to the appropriate hard-coded form arrays in the lims.module file, just as I did in Issue #21 for an older request to add an option to the **Sequence Technology** dropdown

## Testing

### Manual Testing
1. Clone this repository and switch to the branch for this PR: `git checkout 22-addTechLibraryOptions`
2. Setup a KPclone by following the instructions for `Local Clone for Module Development` and mount this repo you just cloned: `lims_rawseq`
3. Go to your new KPclone site and login with your KnowPulse credentials
4. Go to the right-hand sidebar and choose `"Add Sequencing Run"` from the list (the 5th option in the list)
5. On the form, check "Library Type" and make sure **CRISPRclean Ribosomal RNA Depletion (Jumpcode Genomics)** is there
6. Check "Sequencing Technology" and make sure BOTH **Illumina NovaSeq6000** and **Pacbio Revio** are in the list
